### PR TITLE
Update gen.py to comply with python-3.7

### DIFF
--- a/clif/python/gen.py
+++ b/clif/python/gen.py
@@ -731,15 +731,15 @@ def NewIter(wrapped_iter, ns, wrapper, wrapper_type):
 NewIter.name = 'new_iter'
 
 
-def IterNext(wrapped_iter, async, postconversion):
+def IterNext(wrapped_iter, is_async, postconversion):
   """Generate tp_iternext method implementation."""
   yield ''
   yield 'PyObject* iternext(PyObject* self) {'
-  if async:
+  if is_async:
     yield I+'PyThreadState* _save;'
     yield I+'Py_UNBLOCK_THREADS'
   yield I+'auto* v = %s.Next();' % wrapped_iter
-  if async:
+  if is_async:
     yield I+'Py_BLOCK_THREADS'
   yield I+'return v? Clif_PyObjFrom(*v, %s): nullptr;' % postconversion
   yield '}'


### PR DESCRIPTION
The function IterNext had a parameter named `async` but this is a reserved keyword in python-3.7. Just change `async` to `is_async`