### PR TITLE
Update python version requirement check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@
 
 import glob
 import os
-import platform
 # pylint: disable=g-import-not-at-top
 try:
   import setuptools
@@ -24,10 +23,6 @@ except ImportError:
   from ez_setup import use_setuptools
   use_setuptools()
   import setuptools
-
-py_version = platform.python_version_tuple()
-if py_version < ('2', '7') or py_version[0] == '3' and py_version < ('3', '4'):
-  raise RuntimeError('Python version 2.7 or 3.4+ required')
 
 if not os.path.exists('clif/protos/ast_pb2.py'):
   raise RuntimeError('clif/protos/ast_pb2.py not found. See INSTALL.sh.')
@@ -86,6 +81,7 @@ setuptools.setup(
             libraries=['protobuf'],
             ),
         ],
+    python_requires='>=2.7, >=3.4',
     install_requires=[
         'setuptools>=18.5',
         'pyparsing>=2.2.0',


### PR DESCRIPTION
I faced a bug when I was building the pykaldi project on Python 3.10. This happened in the `./install_clif.sh` stage of the process. The error thrown was `Python version 2.7 or 3.4+ required`. This was because the version check returned true for `py_version < ('3', '4')`. The value of `py_version` on my system is `('3', '10', '2'). It turns out that the check was done using strings instead of integers. This will make '10' < '4' which will result in the error above thrown.

I checked the google clif repo and observed that they aren't using the above check anymore. They just use the `python_requires` parameter in the `setuptools.setup()` function. This PR replicates it.

I have tested it on a Mac 11.6 (2019) system with Python 3.10.2 as the interpreter and it works without any error. 