### PR TITLE
Allow installation with Python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except ImportError:
   import setuptools
 
 py_version = platform.python_version_tuple()
-if py_version < ('2', '7') or py_version[0] == '3' and py_version < ('3', '4'):
+if py_version < ('2', '7') or py_version[0] == '3' and int(py_version[1]) < 4:
   raise RuntimeError('Python version 2.7 or 3.4+ required')
 
 if not os.path.exists('clif/protos/ast_pb2.py'):


### PR DESCRIPTION
It seems to compile with this change. This is needed to compile pykaldi by strictly following the instructions [here](https://github.com/pykaldi/pykaldi#step-2-install-dependencies) with Python 3.10.